### PR TITLE
Add observability with Dockerfile

### DIFF
--- a/Dockerfile.observability
+++ b/Dockerfile.observability
@@ -1,0 +1,29 @@
+# Observability Stack for Effect Tracing
+# This Dockerfile sets up Jaeger, OpenTelemetry Collector, and Prometheus
+# for collecting and visualizing traces from Effect applications
+
+FROM grafana/otel-lgtm:latest
+
+# Expose necessary ports
+# Jaeger UI
+EXPOSE 16686
+# OpenTelemetry Collector - OTLP gRPC
+EXPOSE 4317
+# OpenTelemetry Collector - OTLP HTTP  
+EXPOSE 4318
+# Prometheus metrics
+EXPOSE 9090
+# Grafana UI
+EXPOSE 3000
+
+# Set environment variables for better defaults
+ENV JAEGER_ENDPOINT=http://localhost:14268/api/traces
+ENV OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+ENV OTEL_SERVICE_NAME=effect-internal-cli
+
+# Health check to ensure services are running
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+  CMD curl -f http://localhost:16686 || exit 1
+
+# Default command (inherited from base image)
+CMD ["sh", "-c", "exec /otel-lgtm"]

--- a/OBSERVABILITY.md
+++ b/OBSERVABILITY.md
@@ -1,0 +1,367 @@
+# OpenTelemetry Observability for Total TypeScript Internal CLI
+
+This repository includes a complete observability stack for tracing Effect applications using OpenTelemetry. The setup provides distributed tracing capabilities to monitor and debug the internal CLI operations.
+
+## Overview
+
+The observability stack includes:
+
+- **OpenTelemetry Collector**: Receives and processes telemetry data
+- **Jaeger**: Distributed tracing visualization
+- **Prometheus**: Metrics collection and storage
+- **Grafana**: Unified dashboard for metrics and traces
+- **Tempo**: Distributed tracing backend
+- **Loki**: Log aggregation
+
+All components are bundled in the `grafana/otel-lgtm` Docker image for easy deployment.
+
+## Quick Start
+
+### 1. Start the Observability Stack
+
+```bash
+# Using Docker Compose (recommended)
+docker compose -f docker-compose.observability.yml up -d
+
+# Or using Docker directly
+docker run -d \
+  --name effect-observability \
+  -p 16686:16686 \
+  -p 4317:4317 \
+  -p 4318:4318 \
+  -p 9090:9090 \
+  -p 3000:3000 \
+  grafana/otel-lgtm:latest
+```
+
+### 2. Verify the Stack
+
+Once running, you can access:
+
+- **Jaeger UI**: http://localhost:16686 - View distributed traces
+- **Prometheus**: http://localhost:9090 - Query metrics
+- **Grafana**: http://localhost:3000 - Unified dashboards
+
+### 3. Run the Internal CLI
+
+The internal CLI is now instrumented with OpenTelemetry tracing:
+
+```bash
+# Navigate to the internal CLI
+cd apps/internal-cli
+
+# Install dependencies (if not already done)
+pnpm install
+
+# Build the CLI
+pnpm build
+
+# Run any CLI command - traces will be automatically sent to the observability stack
+pnpm tt queue-status
+pnpm tt create-auto-edited-video
+pnpm tt process-queue
+```
+
+## Configuration
+
+### Environment Variables
+
+You can configure the observability setup using environment variables:
+
+```bash
+# OpenTelemetry endpoint (defaults to http://localhost:4318/v1/traces)
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318/v1/traces"
+
+# Service name (defaults to "total-typescript-internal-cli") 
+export OTEL_SERVICE_NAME="total-typescript-internal-cli"
+
+# Enable/disable tracing (defaults to enabled)
+export OTEL_TRACES_EXPORTER="otlp"
+```
+
+### Docker Compose Configuration
+
+The `docker-compose.observability.yml` file provides a complete setup:
+
+```yaml
+version: '3.8'
+
+services:
+  observability:
+    image: grafana/otel-lgtm:latest
+    container_name: effect-observability
+    ports:
+      - "16686:16686"  # Jaeger UI
+      - "4317:4317"    # OTLP gRPC
+      - "4318:4318"    # OTLP HTTP
+      - "9090:9090"    # Prometheus
+      - "3000:3000"    # Grafana
+    environment:
+      - OTEL_SERVICE_NAME=effect-internal-cli
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:16686"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+```
+
+## Architecture
+
+### Component Overview
+
+```
+┌─────────────────┐    ┌──────────────────┐    ┌─────────────────┐
+│   Internal CLI  │───▶│ OpenTelemetry    │───▶│ Observability   │
+│   (Effect App)  │    │ Collector        │    │ Stack (LGTM)    │
+└─────────────────┘    └──────────────────┘    └─────────────────┘
+                               │                         │
+                               ▼                         ▼
+                       ┌──────────────┐         ┌─────────────────┐
+                       │ Jaeger Traces│         │ Prometheus      │
+                       │ Grafana      │         │ Tempo           │
+                       │ Loki Logs    │         │ Loki            │
+                       └──────────────┘         └─────────────────┘
+```
+
+### Effect Integration
+
+The internal CLI integrates OpenTelemetry using Effect's built-in tracing capabilities:
+
+1. **OpenTelemetry Layer**: Configured in `apps/internal-cli/src/tracing.ts`
+2. **Effect Integration**: Uses `@effect/opentelemetry` for seamless tracing
+3. **Automatic Instrumentation**: All Effect operations are automatically traced
+4. **Structured Logging**: Console logs are correlated with traces
+
+### Tracing Setup
+
+The tracing setup follows Effect best practices:
+
+```typescript
+// apps/internal-cli/src/tracing.ts
+export const OpenTelemetryLive = NodeSdk.layer(() => ({
+  resource: {
+    serviceName: "total-typescript-internal-cli",
+    serviceVersion: "1.0.0",
+  },
+  spanProcessor: new BatchSpanProcessor(
+    new OTLPTraceExporter({
+      url: getOtelEndpoint(),
+      headers: {},
+    })
+  ),
+}))
+
+// apps/internal-cli/src/bin.ts  
+const MainLayerLive = Layer.provide(AppLayerLive, OpenTelemetryLive);
+```
+
+## Using the Observability Tools
+
+### Jaeger - Distributed Tracing
+
+Access Jaeger at http://localhost:16686
+
+**Key Features:**
+- View end-to-end request traces
+- Analyze service dependencies
+- Identify performance bottlenecks
+- Debug error propagation
+
+**Usage:**
+1. Select service: `total-typescript-internal-cli`
+2. Choose operation (e.g., `queue-status`, `create-auto-edited-video`)
+3. Set time range and click "Find Traces"
+4. Click on traces to view detailed span information
+
+### Prometheus - Metrics
+
+Access Prometheus at http://localhost:9090
+
+**Useful Queries:**
+```promql
+# Trace span metrics
+traces_spanmetrics_calls_total
+traces_spanmetrics_latency_bucket
+traces_spanmetrics_latency_count
+
+# Service health
+up{job="jaeger"}
+```
+
+### Grafana - Unified Dashboard
+
+Access Grafana at http://localhost:3000
+
+**Default Credentials:**
+- Username: `admin`
+- Password: `admin`
+
+**Pre-configured Data Sources:**
+- Prometheus (metrics)
+- Tempo (traces)  
+- Loki (logs)
+
+## CLI Command Tracing
+
+Each CLI command is automatically instrumented:
+
+### Example: Video Processing Trace
+
+```bash
+pnpm tt create-auto-edited-video --upload --generate-article
+```
+
+This creates a trace showing:
+1. **Root Span**: `create-auto-edited-video` command
+2. **Child Spans**: 
+   - OBS video retrieval
+   - User input collection
+   - Queue item creation
+   - File operations
+   - Article generation workflow
+
+### Example: Queue Processing Trace
+
+```bash
+pnpm tt process-queue
+```
+
+This creates traces for:
+1. Queue state retrieval
+2. Individual item processing
+3. FFmpeg operations
+4. File system operations
+5. External API calls
+
+## Troubleshooting
+
+### Common Issues
+
+**1. No traces appearing in Jaeger**
+
+Check that the observability stack is running:
+```bash
+docker ps | grep effect-observability
+curl http://localhost:16686/api/services
+```
+
+**2. Connection refused errors**
+
+Verify the OTLP endpoint is correct:
+```bash
+curl http://localhost:4318/v1/traces
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318/v1/traces"
+```
+
+**3. CLI not sending traces**
+
+Ensure dependencies are installed:
+```bash
+cd apps/internal-cli
+pnpm install
+pnpm build
+```
+
+### Health Checks
+
+The observability stack includes health checks:
+
+```bash
+# Check container health
+docker inspect effect-observability | grep Health -A 10
+
+# Manual health check
+curl -f http://localhost:16686 && echo "Jaeger OK"
+curl -f http://localhost:9090 && echo "Prometheus OK"  
+curl -f http://localhost:3000 && echo "Grafana OK"
+```
+
+### Logs
+
+View container logs for debugging:
+
+```bash
+# View all logs
+docker logs effect-observability
+
+# Follow logs in real-time
+docker logs -f effect-observability
+
+# View specific component logs
+docker logs effect-observability | grep jaeger
+docker logs effect-observability | grep prometheus
+```
+
+## Advanced Configuration
+
+### Custom OTLP Endpoint
+
+To send traces to a different endpoint:
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT="https://your-otel-endpoint.com/v1/traces"
+export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer your-token"
+```
+
+### Sampling Configuration
+
+Configure trace sampling in the tracing setup:
+
+```typescript
+// Reduce trace volume in production
+export const OpenTelemetryLive = NodeSdk.layer(() => ({
+  resource: { serviceName: "total-typescript-internal-cli" },
+  spanProcessor: new BatchSpanProcessor(
+    new OTLPTraceExporter({ url: getOtelEndpoint() })
+  ),
+  sampler: TraceIdRatioBasedSampler(0.1), // 10% sampling
+}))
+```
+
+### Production Deployment
+
+For production use:
+
+1. **Use external observability service** (e.g., Grafana Cloud, Datadog)
+2. **Configure authentication** and secure endpoints
+3. **Set up proper sampling** to manage data volume
+4. **Monitor resource usage** of the observability stack
+5. **Configure data retention** policies
+
+## Dependencies
+
+The observability setup uses these key dependencies:
+
+```json
+{
+  "@effect/opentelemetry": "^0.40.0",
+  "@opentelemetry/exporter-trace-otlp-http": "^0.54.2",
+  "@opentelemetry/sdk-trace-base": "^1.28.0",
+  "@opentelemetry/sdk-trace-node": "^1.28.0",
+  "@opentelemetry/sdk-metrics": "^1.28.0",
+  "@opentelemetry/semantic-conventions": "^1.28.0",
+  "@opentelemetry/resources": "^1.28.0"
+}
+```
+
+## Contributing
+
+When adding new CLI commands or modifying existing ones:
+
+1. **Use Effect patterns** - All operations automatically get traced
+2. **Add meaningful span names** using `Effect.withSpan("operation-name")`
+3. **Include context** in span attributes for debugging
+4. **Test tracing** by running commands and checking Jaeger
+5. **Document new traces** in this README
+
+## Support
+
+For issues with the observability setup:
+
+1. Check the [OpenTelemetry Documentation](https://opentelemetry.io/docs/)
+2. Review [Effect Tracing Guide](https://effect.website/docs/observability/tracing/)
+3. Examine container logs for specific error messages
+4. Verify network connectivity between components
+
+The observability stack provides powerful insights into the Total TypeScript internal CLI operations, helping with debugging, performance optimization, and understanding application behavior.

--- a/apps/internal-cli/package.json
+++ b/apps/internal-cli/package.json
@@ -15,7 +15,8 @@
   },
   "devDependencies": {
     "@total-typescript/ts-reset": "^0.5.1",
-    "@types/prompts": "^2.4.9"
+    "@types/prompts": "^2.4.9",
+    "@types/node": "^22.0.0"
   },
   "dependencies": {
     "@total-typescript/shared": "workspace:*",
@@ -25,6 +26,13 @@
     "fast-glob": "^3.3.2",
     "prompts": "^2.4.2",
     "effect": "^3.16.8",
-    "@effect/platform": "^0.85.2"
+    "@effect/platform": "^0.85.2",
+    "@effect/opentelemetry": "^0.40.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.54.2",
+    "@opentelemetry/sdk-trace-base": "^1.28.0",
+    "@opentelemetry/sdk-trace-node": "^1.28.0",
+    "@opentelemetry/sdk-metrics": "^1.28.0",
+    "@opentelemetry/semantic-conventions": "^1.28.0",
+    "@opentelemetry/resources": "^1.28.0"
   }
 }

--- a/apps/internal-cli/src/bin.ts
+++ b/apps/internal-cli/src/bin.ts
@@ -24,7 +24,7 @@ import {
 import { type AbsolutePath } from "@total-typescript/shared";
 import { Command } from "commander";
 import { config } from "dotenv";
-import { ConfigProvider, Console, Effect } from "effect";
+import { ConfigProvider, Console, Effect, Layer } from "effect";
 import path from "node:path";
 import { styleText } from "node:util";
 import {
@@ -34,10 +34,16 @@ import {
   TranscriptStorageService,
 } from "../../../packages/ffmpeg/dist/services.js";
 import packageJson from "../package.json" with { type: "json" };
+import { OpenTelemetryLive } from "./tracing.js";
 
 config({
   path: path.resolve(import.meta.dirname, "../../../.env"),
 });
+
+/**
+ * Main Layer that combines the application layer with OpenTelemetry tracing
+ */
+const MainLayerLive = Layer.provide(AppLayerLive, OpenTelemetryLive);
 
 const program = new Command();
 
@@ -50,7 +56,7 @@ program
   .action(async () => {
     await moveRawFootageToLongTermStorage().pipe(
       Effect.withConfigProvider(ConfigProvider.fromEnv()),
-      Effect.provide(AppLayerLive),
+      Effect.provide(MainLayerLive),
       Effect.runPromise
     );
   });
@@ -61,7 +67,7 @@ program
   .action(async () => {
     await createTimeline().pipe(
       Effect.withConfigProvider(ConfigProvider.fromEnv()),
-      Effect.provide(AppLayerLive),
+      Effect.provide(MainLayerLive),
       Effect.runPromise
     );
   });
@@ -72,7 +78,7 @@ program
   .action(async () => {
     await addCurrentTimelineToRenderQueue().pipe(
       Effect.withConfigProvider(ConfigProvider.fromEnv()),
-      Effect.provide(AppLayerLive),
+      Effect.provide(MainLayerLive),
       Effect.runPromise
     );
   });
@@ -83,7 +89,7 @@ program
   .action(async () => {
     await exportSubtitles().pipe(
       Effect.withConfigProvider(ConfigProvider.fromEnv()),
-      Effect.provide(AppLayerLive),
+      Effect.provide(MainLayerLive),
       Effect.runPromise
     );
   });
@@ -97,7 +103,7 @@ program
       inputVideo: video as AbsolutePath,
     }).pipe(
       Effect.withConfigProvider(ConfigProvider.fromEnv()),
-      Effect.provide(AppLayerLive),
+      Effect.provide(MainLayerLive),
       Effect.runPromise
     );
   });
@@ -154,7 +160,7 @@ program
         });
       }),
       Effect.withConfigProvider(ConfigProvider.fromEnv()),
-      Effect.provide(AppLayerLive),
+      Effect.provide(MainLayerLive),
       Effect.runPromise
     );
   });
@@ -166,7 +172,7 @@ program
   .action(async () => {
     await transcribeVideoWorkflow().pipe(
       Effect.withConfigProvider(ConfigProvider.fromEnv()),
-      Effect.provide(AppLayerLive),
+      Effect.provide(MainLayerLive),
       Effect.runPromise
     );
   });
@@ -178,7 +184,7 @@ program
   .action(async () => {
     await processQueue().pipe(
       Effect.withConfigProvider(ConfigProvider.fromEnv()),
-      Effect.provide(AppLayerLive),
+      Effect.provide(MainLayerLive),
       Effect.runPromise
     );
   });
@@ -200,7 +206,7 @@ program
       yield* processInformationRequests();
     }).pipe(
       Effect.withConfigProvider(ConfigProvider.fromEnv()),
-      Effect.provide(AppLayerLive),
+      Effect.provide(MainLayerLive),
       Effect.runPromise
     );
   });
@@ -264,7 +270,7 @@ program
 
     await program.pipe(
       Effect.withConfigProvider(ConfigProvider.fromEnv()),
-      Effect.provide(AppLayerLive),
+      Effect.provide(MainLayerLive),
       Effect.runPromise
     );
   });
@@ -393,7 +399,7 @@ program
       }
     }).pipe(
       Effect.withConfigProvider(ConfigProvider.fromEnv()),
-      Effect.provide(AppLayerLive),
+      Effect.provide(MainLayerLive),
       Effect.runPromise
     );
   });
@@ -454,7 +460,7 @@ program
         });
       }),
       Effect.withConfigProvider(ConfigProvider.fromEnv()),
-      Effect.provide(AppLayerLive),
+      Effect.provide(MainLayerLive),
       Effect.runPromise
     );
   });

--- a/apps/internal-cli/src/tracing.ts
+++ b/apps/internal-cli/src/tracing.ts
@@ -1,0 +1,34 @@
+import { NodeSdk } from "@effect/opentelemetry"
+import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-base"
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http"
+
+/**
+ * Get OpenTelemetry endpoint from environment or default
+ */
+const getOtelEndpoint = (): string => {
+  return process.env.OTEL_EXPORTER_OTLP_ENDPOINT || "http://localhost:4318/v1/traces"
+}
+
+/**
+ * OpenTelemetry Layer for the internal CLI
+ * Configures tracing to send data to the observability stack
+ */
+export const OpenTelemetryLive = NodeSdk.layer(() => ({
+  resource: {
+    serviceName: "total-typescript-internal-cli",
+    serviceVersion: "1.0.0",
+  },
+  spanProcessor: new BatchSpanProcessor(
+    new OTLPTraceExporter({
+      url: getOtelEndpoint(),
+      headers: {},
+    })
+  ),
+}))
+
+export const getServiceName = (): string => {
+  if (typeof process !== 'undefined' && process.env) {
+    return process.env.OTEL_SERVICE_NAME || "total-typescript-internal-cli"
+  }
+  return "total-typescript-internal-cli"
+}

--- a/apps/internal-cli/src/tracing.ts
+++ b/apps/internal-cli/src/tracing.ts
@@ -1,34 +1,44 @@
 import { NodeSdk } from "@effect/opentelemetry"
 import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-base"
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http"
+import { Config, Effect, Layer } from "effect"
 
 /**
- * Get OpenTelemetry endpoint from environment or default
+ * Configuration for OpenTelemetry endpoint
  */
-const getOtelEndpoint = (): string => {
-  return process.env.OTEL_EXPORTER_OTLP_ENDPOINT || "http://localhost:4318/v1/traces"
-}
+const otelEndpointConfig = Config.string("OTEL_EXPORTER_OTLP_ENDPOINT").pipe(
+  Config.withDefault("http://localhost:4318/v1/traces")
+)
+
+/**
+ * Configuration for service name
+ */
+const serviceNameConfig = Config.string("OTEL_SERVICE_NAME").pipe(
+  Config.withDefault("total-typescript-internal-cli")
+)
 
 /**
  * OpenTelemetry Layer for the internal CLI
  * Configures tracing to send data to the observability stack
  */
-export const OpenTelemetryLive = NodeSdk.layer(() => ({
-  resource: {
-    serviceName: "total-typescript-internal-cli",
-    serviceVersion: "1.0.0",
-  },
-  spanProcessor: new BatchSpanProcessor(
-    new OTLPTraceExporter({
-      url: getOtelEndpoint(),
-      headers: {},
-    })
-  ),
-}))
-
-export const getServiceName = (): string => {
-  if (typeof process !== 'undefined' && process.env) {
-    return process.env.OTEL_SERVICE_NAME || "total-typescript-internal-cli"
-  }
-  return "total-typescript-internal-cli"
-}
+export const OpenTelemetryLive = Layer.unwrapEffect(
+  Effect.all({
+    endpoint: otelEndpointConfig,
+    serviceName: serviceNameConfig
+  }).pipe(
+    Effect.map(({ endpoint, serviceName }) =>
+      NodeSdk.layer(() => ({
+        resource: {
+          serviceName,
+          serviceVersion: "1.0.0",
+        },
+        spanProcessor: new BatchSpanProcessor(
+          new OTLPTraceExporter({
+            url: endpoint,
+            headers: {},
+          })
+        ),
+      }))
+    )
+  )
+)

--- a/docker-compose.observability.yml
+++ b/docker-compose.observability.yml
@@ -1,0 +1,35 @@
+version: '3.8'
+
+services:
+  # All-in-one observability stack for Effect tracing
+  observability:
+    image: grafana/otel-lgtm:latest
+    container_name: effect-observability
+    ports:
+      # Jaeger UI
+      - "16686:16686"
+      # OpenTelemetry Collector - OTLP gRPC
+      - "4317:4317"
+      # OpenTelemetry Collector - OTLP HTTP
+      - "4318:4318"
+      # Prometheus
+      - "9090:9090"
+      # Grafana
+      - "3000:3000"
+    environment:
+      - OTEL_SERVICE_NAME=effect-internal-cli
+      - JAEGER_ENDPOINT=http://localhost:14268/api/traces
+    volumes:
+      # Optional: mount config if you want to customize
+      - ./observability-config:/etc/otel-lgtm
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:16686"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+networks:
+  default:
+    name: effect-observability

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,9 +47,30 @@ importers:
 
   apps/internal-cli:
     dependencies:
+      '@effect/opentelemetry':
+        specifier: ^0.40.0
+        version: 0.40.2(@opentelemetry/api@1.9.0)(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-node@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.34.0)(effect@3.16.8)
       '@effect/platform':
         specifier: ^0.85.2
         version: 0.85.2(effect@3.16.8)
+      '@opentelemetry/exporter-trace-otlp-http':
+        specifier: ^0.54.2
+        version: 0.54.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources':
+        specifier: ^1.28.0
+        version: 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics':
+        specifier: ^1.28.0
+        version: 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base':
+        specifier: ^1.28.0
+        version: 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-node':
+        specifier: ^1.28.0
+        version: 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions':
+        specifier: ^1.28.0
+        version: 1.34.0
       '@total-typescript/ffmpeg':
         specifier: workspace:*
         version: link:../../packages/ffmpeg
@@ -75,6 +96,9 @@ importers:
       '@total-typescript/ts-reset':
         specifier: ^0.5.1
         version: 0.5.1
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.15.3
       '@types/prompts':
         specifier: ^2.4.9
         version: 2.4.9
@@ -1075,6 +1099,27 @@ packages:
 
   '@effect/language-service@0.23.3':
     resolution: {integrity: sha512-yurF+FHd1HwM/3Mh7kQCea+z4wvbs2/NLPyk6FiEWA2sppRKv4Kp4luwfUqWqyd9/uyScWJcHX7WK1caLpx4Pw==}
+
+  '@effect/opentelemetry@0.40.2':
+    resolution: {integrity: sha512-8p8nxsL4cjtawJUsxz7XiFetJVKR9DPNH3I3At4kV/QPbC7WRYx6332I8Zk9nzSmaNcQwMMUZFu3UjZPMWyNXw==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.6
+      '@opentelemetry/resources': ^1.22
+      '@opentelemetry/sdk-metrics': ^1.22
+      '@opentelemetry/sdk-trace-base': ^1.22
+      '@opentelemetry/sdk-trace-node': ^1.22
+      '@opentelemetry/sdk-trace-web': ^1.22
+      '@opentelemetry/semantic-conventions': ^1.24.1
+      effect: ^3.11.2
+    peerDependenciesMeta:
+      '@opentelemetry/sdk-metrics':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+      '@opentelemetry/sdk-trace-node':
+        optional: true
+      '@opentelemetry/sdk-trace-web':
+        optional: true
 
   '@effect/platform-node-shared@0.40.4':
     resolution: {integrity: sha512-EfnRTSHKs33OTfKN9pF+G2AyxMXm/+4rKrGM8yEw56Ij6QV5dq2g28yi0eOH7BytvilnreVmcbAec7M77EArgg==}
@@ -2164,9 +2209,117 @@ packages:
     resolution: {integrity: sha512-gGq0NJkIGSwdbUt4yhdF8ZrmkGKVz9vAdVzpOfnom+V8PLSmSOVhZwbNvZZS1EYcJN5hzzKBxmmVVAInM6HQLg==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  '@opentelemetry/api-logs@0.54.2':
+    resolution: {integrity: sha512-4MTVwwmLgUh5QrJnZpYo6YRO5IBLAggf2h8gWDblwRagDStY13aEvt7gGk3jewrMaPlHiF83fENhIx0HO97/cQ==}
+    engines: {node: '>=14'}
+
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/context-async-hooks@1.30.1':
+    resolution: {integrity: sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@1.27.0':
+    resolution: {integrity: sha512-yQPKnK5e+76XuiqUH/gKyS8wv/7qITd5ln56QkBTf3uggr0VkXOXfcaAuG330UfdYu83wsyoBwqwxigpIG+Jkg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@1.30.1':
+    resolution: {integrity: sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/exporter-trace-otlp-http@0.54.2':
+    resolution: {integrity: sha512-BgWKKyD/h2zpISdmYHN/sapwTjvt1P4p5yx4xeBV8XAEqh4OQUhOtSGFG80+nPQ1F8of3mKOT1DDoDbJp1u25w==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-exporter-base@0.54.2':
+    resolution: {integrity: sha512-NrNyxu6R/bGAwanhz1HI0aJWKR6xUED4TjCH4iWMlAfyRukGbI9Kt/Akd2sYLwRKNhfS+sKetKGCUQPMDyYYMA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.54.2':
+    resolution: {integrity: sha512-2tIjahJlMRRUz0A2SeE+qBkeBXBFkSjR0wqJ08kuOqaL8HNGan5iZf+A8cfrfmZzPUuMKCyY9I+okzFuFs6gKQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/propagator-b3@1.30.1':
+    resolution: {integrity: sha512-oATwWWDIJzybAZ4pO76ATN5N6FFbOA1otibAVlS8v90B4S1wClnhRUk7K+2CHAwN1JKYuj4jh/lpCEG5BAqFuQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/propagator-jaeger@1.30.1':
+    resolution: {integrity: sha512-Pj/BfnYEKIOImirH76M4hDaBSx6HyZ2CXUqk+Kj02m6BB80c/yo4BdWkn/1gDFfU+YPY+bPR2U0DKBfdxCKwmg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/resources@1.27.0':
+    resolution: {integrity: sha512-jOwt2VJ/lUD5BLc+PMNymDrUCpm5PKi1E9oSVYAvz01U/VdndGmrtV3DU1pG4AwlYhJRHbHfOUIlpBeXCPw6QQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/resources@1.30.1':
+    resolution: {integrity: sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.54.2':
+    resolution: {integrity: sha512-yIbYqDLS/AtBbPjCjh6eSToGNRMqW2VR8RrKEy+G+J7dFG7pKoptTH5T+XlKPleP9NY8JZYIpgJBlI+Osi0rFw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@1.27.0':
+    resolution: {integrity: sha512-JzWgzlutoXCydhHWIbLg+r76m+m3ncqvkCcsswXAQ4gqKS+LOHKhq+t6fx1zNytvLuaOUBur7EvWxECc4jPQKg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@1.30.1':
+    resolution: {integrity: sha512-q9zcZ0Okl8jRgmy7eNW3Ku1XSgg3sDLa5evHZpCwjspw7E8Is4K/haRPDJrBcX3YSn/Y7gUvFnByNYEKQNbNog==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@1.27.0':
+    resolution: {integrity: sha512-btz6XTQzwsyJjombpeqCX6LhiMQYpzt2pIYNPnw0IPO/3AhT6yjnf8Mnv3ZC2A4eRYOjqrg+bfaXg9XHDRJDWQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@1.30.1':
+    resolution: {integrity: sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-node@1.30.1':
+    resolution: {integrity: sha512-cBjYOINt1JxXdpw1e5MlHmFRc5fgj4GW/86vsKFxJCJ8AL4PdVtYH41gWwl4qd4uQjqEL1oJVrXkSy5cnduAnQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.27.0':
+    resolution: {integrity: sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==}
+    engines: {node: '>=14'}
+
+  '@opentelemetry/semantic-conventions@1.28.0':
+    resolution: {integrity: sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==}
+    engines: {node: '>=14'}
 
   '@opentelemetry/semantic-conventions@1.34.0':
     resolution: {integrity: sha512-aKcOkyrorBGlajjRdVoJWHTxfxO1vCNHLJVlSDaRHDIdjU+pX8IYQPvPDkYiujKLbRnWU+1TBwEt0QRgSm4SGA==}
@@ -2363,6 +2516,36 @@ packages:
 
   '@prisma/get-platform@5.19.1':
     resolution: {integrity: sha512-sCeoJ+7yt0UjnR+AXZL7vXlg5eNxaFOwC23h0KvW1YIXUoa7+W2ZcAUhoEQBmJTW4GrFqCuZ8YSP0mkDa4k3Zg==}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.4':
+    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.0':
+    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.0':
+    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
   '@puppeteer/browsers@2.3.0':
     resolution: {integrity: sha512-ioXoq9gPxkss4MYhD+SFaU9p1IHFUX0ILAWFPyjGaBdjLsYAlZw6j1iLA0N/m12uVHLFDfSYNF7EQccjinIMDA==}
@@ -5301,6 +5484,9 @@ packages:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
 
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
@@ -6267,6 +6453,10 @@ packages:
 
   property-information@6.5.0:
     resolution: {integrity: sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==}
+
+  protobufjs@7.5.3:
+    resolution: {integrity: sha512-sildjKwVqOI2kmFDiXQ6aEB0fjYTafpEvIBs8tOR8qI4spuL9OPROLVu2qZqi/xgCfsHIwVqlaF8JBjWFHnKbw==}
+    engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -8458,6 +8648,17 @@ snapshots:
 
   '@effect/language-service@0.23.3': {}
 
+  '@effect/opentelemetry@0.40.2(@opentelemetry/api@1.9.0)(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-node@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.34.0)(effect@3.16.8)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.34.0
+      effect: 3.16.8
+    optionalDependencies:
+      '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-node': 1.30.1(@opentelemetry/api@1.9.0)
+
   '@effect/platform-node-shared@0.40.4(@effect/cluster@0.39.4(@effect/platform@0.85.2(effect@3.16.8))(@effect/rpc@0.62.4(@effect/platform@0.85.2(effect@3.16.8))(effect@3.16.8))(@effect/sql@0.38.2(@effect/experimental@0.49.2(@effect/platform@0.85.2(effect@3.16.8))(effect@3.16.8))(@effect/platform@0.85.2(effect@3.16.8))(effect@3.16.8))(@effect/workflow@0.2.4(@effect/platform@0.85.2(effect@3.16.8))(@effect/rpc@0.62.4(@effect/platform@0.85.2(effect@3.16.8))(effect@3.16.8))(effect@3.16.8))(effect@3.16.8))(@effect/platform@0.85.2(effect@3.16.8))(@effect/rpc@0.62.4(@effect/platform@0.85.2(effect@3.16.8))(effect@3.16.8))(@effect/sql@0.38.2(@effect/experimental@0.49.2(@effect/platform@0.85.2(effect@3.16.8))(effect@3.16.8))(@effect/platform@0.85.2(effect@3.16.8))(effect@3.16.8))(effect@3.16.8)':
     dependencies:
       '@effect/cluster': 0.39.4(@effect/platform@0.85.2(effect@3.16.8))(@effect/rpc@0.62.4(@effect/platform@0.85.2(effect@3.16.8))(effect@3.16.8))(@effect/sql@0.38.2(@effect/experimental@0.49.2(@effect/platform@0.85.2(effect@3.16.8))(effect@3.16.8))(@effect/platform@0.85.2(effect@3.16.8))(effect@3.16.8))(@effect/workflow@0.2.4(@effect/platform@0.85.2(effect@3.16.8))(@effect/rpc@0.62.4(@effect/platform@0.85.2(effect@3.16.8))(effect@3.16.8))(effect@3.16.8))(effect@3.16.8)
@@ -9150,7 +9351,7 @@ snapshots:
 
   '@npmcli/fs@3.1.1':
     dependencies:
-      semver: 7.6.3
+      semver: 7.7.2
 
   '@npmcli/git@4.1.0':
     dependencies:
@@ -9160,7 +9361,7 @@ snapshots:
       proc-log: 3.0.0
       promise-inflight: 1.0.1
       promise-retry: 2.0.1
-      semver: 7.6.3
+      semver: 7.7.2
       which: 3.0.1
     transitivePeerDependencies:
       - bluebird
@@ -9173,7 +9374,7 @@ snapshots:
       json-parse-even-better-errors: 3.0.2
       normalize-package-data: 5.0.0
       proc-log: 3.0.0
-      semver: 7.6.3
+      semver: 7.7.2
     transitivePeerDependencies:
       - bluebird
 
@@ -9181,7 +9382,120 @@ snapshots:
     dependencies:
       which: 3.0.1
 
+  '@opentelemetry/api-logs@0.54.2':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
   '@opentelemetry/api@1.9.0': {}
+
+  '@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
+  '@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.27.0
+
+  '@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/exporter-trace-otlp-http@0.54.2(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.27.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.54.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.54.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.27.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 1.27.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/otlp-exporter-base@0.54.2(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.27.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.54.2(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/otlp-transformer@0.54.2(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.54.2
+      '@opentelemetry/core': 1.27.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.27.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.54.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 1.27.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 1.27.0(@opentelemetry/api@1.9.0)
+      protobufjs: 7.5.3
+
+  '@opentelemetry/propagator-b3@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/propagator-jaeger@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/resources@1.27.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.27.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.27.0
+
+  '@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/sdk-logs@0.54.2(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.54.2
+      '@opentelemetry/core': 1.27.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.27.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/sdk-metrics@1.27.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.27.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.27.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.27.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.27.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.27.0
+
+  '@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/sdk-trace-node@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/context-async-hooks': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/propagator-b3': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/propagator-jaeger': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
+      semver: 7.7.2
+
+  '@opentelemetry/semantic-conventions@1.27.0': {}
+
+  '@opentelemetry/semantic-conventions@1.28.0': {}
 
   '@opentelemetry/semantic-conventions@1.34.0': {}
 
@@ -9333,6 +9647,29 @@ snapshots:
   '@prisma/get-platform@5.19.1':
     dependencies:
       '@prisma/debug': 5.19.1
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.4': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.0
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.0': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.0': {}
 
   '@puppeteer/browsers@2.3.0':
     dependencies:
@@ -10397,6 +10734,7 @@ snapshots:
   '@types/node@24.0.7':
     dependencies:
       undici-types: 7.8.0
+    optional: true
 
   '@types/nprogress@0.2.3': {}
 
@@ -12466,7 +12804,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 24.0.7
+      '@types/node': 22.15.3
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -12667,6 +13005,8 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
+
+  long@5.3.2: {}
 
   longest-streak@3.1.0: {}
 
@@ -13217,7 +13557,7 @@ snapshots:
     dependencies:
       hosted-git-info: 6.1.1
       is-core-module: 2.15.0
-      semver: 7.6.3
+      semver: 7.7.2
       validate-npm-package-license: 3.0.4
 
   normalize-path@3.0.0: {}
@@ -13226,7 +13566,7 @@ snapshots:
 
   npm-install-checks@6.3.0:
     dependencies:
-      semver: 7.6.3
+      semver: 7.7.2
 
   npm-normalize-package-bin@3.0.1: {}
 
@@ -13234,7 +13574,7 @@ snapshots:
     dependencies:
       hosted-git-info: 6.1.1
       proc-log: 3.0.0
-      semver: 7.6.3
+      semver: 7.7.2
       validate-npm-package-name: 5.0.1
 
   npm-pick-manifest@8.0.2:
@@ -13242,7 +13582,7 @@ snapshots:
       npm-install-checks: 6.3.0
       npm-normalize-package-bin: 3.0.1
       npm-package-arg: 10.1.0
-      semver: 7.6.3
+      semver: 7.7.2
 
   npm-run-path@4.0.1:
     dependencies:
@@ -13861,6 +14201,21 @@ snapshots:
       sisteransi: 1.0.5
 
   property-information@6.5.0: {}
+
+  protobufjs@7.5.3:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/node': 22.15.3
+      long: 5.3.2
 
   proxy-addr@2.0.7:
     dependencies:
@@ -14785,7 +15140,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici-types@7.8.0: {}
+  undici-types@7.8.0:
+    optional: true
 
   undici@6.19.8: {}
 


### PR DESCRIPTION
Add OpenTelemetry observability stack and integrate it with the internal CLI to enable tracing of operations.

This PR fulfills the request to add observability for the internal CLI, allowing users to follow traces of what has happened and when, by setting up a local Docker-based observability stack (Jaeger, OpenTelemetry Collector, Prometheus, Grafana) and integrating it with Effect's tracing capabilities.